### PR TITLE
Remove flags for setting sysroot and isystem for NDK builds

### DIFF
--- a/config/android/BUILD.gn
+++ b/config/android/BUILD.gn
@@ -75,9 +75,6 @@ config("compiler") {
   }
   cflags += [
     "--target=$abi_target",
-    "-isystem" +
-        rebase_path("$android_ndk_root/sysroot/usr/include/$abi_target",
-                    root_build_dir),
     "-D__ANDROID_API__=$compile_api_level",
   ]
   ldflags += [ "--target=$abi_target" ]
@@ -105,9 +102,7 @@ config("runtime_library") {
   # arm-linux-androideabi-4.4.3 toolchain (circa Gingerbread) will exhibit
   # strange errors. The include ordering here is important; change with
   # caution.
-  cflags_cc = [ "-isystem" +
-                rebase_path("$android_ndk_root/sources/android/support/include",
-                            root_build_dir) ]
+  cflags_cc = []
 
   defines = [
     "__GNU_SOURCE=1",  # Necessary for clone().

--- a/config/posix/BUILD.gn
+++ b/config/posix/BUILD.gn
@@ -25,7 +25,7 @@ config("runtime_library") {
   defines = []
   ldflags = []
 
-  if (!is_mac && !is_ios && sysroot != "") {
+  if (!is_mac && !is_ios && !is_android && sysroot != "") {
     # Pass the sysroot to all C compiler variants, the assembler, and linker.
     sysroot_flags = [ "--sysroot=" + rebase_path(sysroot, root_build_dir) ]
     if (is_linux) {


### PR DESCRIPTION
As of NDK r19 the standalone toolchain don't need those flags to be specified as clang automatically finds them.